### PR TITLE
Compatibility with new pebble-tool

### DIFF
--- a/helloaccelerometer/package.json
+++ b/helloaccelerometer/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS Accelerometer",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf4f",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/helloaccelerometer/setup.sh
+++ b/helloaccelerometer/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.helloaccelerometer
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellobattery/package.json
+++ b/hellobattery/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS Battery",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf4f",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellobattery/setup.sh
+++ b/hellobattery/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellobattery
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellobutton/package.json
+++ b/hellobutton/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS Button",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf50",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellobutton/setup.sh
+++ b/hellobutton/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellobutton
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellofetch/package.json
+++ b/hellofetch/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Fetch",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf6A",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellofetch/setup.sh
+++ b/hellofetch/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.fetch
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-pypkjs ./build/hellofetch.pbw  --debug

--- a/hellohttpclient/package.json
+++ b/hellohttpclient/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - HTTPClient",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf68",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellohttpclient/setup.sh
+++ b/hellohttpclient/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.httpclient
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-pypkjs ./build/hellohttpclient.pbw  --debug

--- a/hellokeyvalue/package.json
+++ b/hellokeyvalue/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS Key-Value",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf4f",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellokeyvalue/setup.sh
+++ b/hellokeyvalue/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.keyvalue
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellolocalstorage/package.json
+++ b/hellolocalstorage/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - localStorage",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf4f",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellolocalstorage/setup.sh
+++ b/hellolocalstorage/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellolocalstorage
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellomessage/package.json
+++ b/hellomessage/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Message",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf52",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellomessage/setup.sh
+++ b/hellomessage/setup.sh
@@ -1,9 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellomessage
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344
-pypkjs ./build/hellomessage.pbw  --debug

--- a/hellomodule/package.json
+++ b/hellomodule/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Module",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf4d",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellomodule/setup.sh
+++ b/hellomodule/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopebble
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopebble/package.json
+++ b/hellopebble/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Hello",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf4c",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopebble/setup.sh
+++ b/hellopebble/setup.sh
@@ -1,9 +1,0 @@
-set -e
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopebble
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-balls/package.json
+++ b/hellopiu-balls/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu Balls",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf6D",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-balls/setup.sh
+++ b/hellopiu-balls/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiu-balls
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-coloredsquares/package.json
+++ b/hellopiu-coloredsquares/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu Squares",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf69",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-coloredsquares/setup.sh
+++ b/hellopiu-coloredsquares/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiu-coloredsquares
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-gbitmap/package.json
+++ b/hellopiu-gbitmap/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu GBitmap",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf80",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-gbitmap/setup.sh
+++ b/hellopiu-gbitmap/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiu-gbitmap
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-jsicon/package.json
+++ b/hellopiu-jsicon/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu JS-Icon",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf6C",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-jsicon/setup.sh
+++ b/hellopiu-jsicon/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiu-js-icon
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-pebbletext/package.json
+++ b/hellopiu-pebbletext/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu Pbl Text",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf80",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-pebbletext/setup.sh
+++ b/hellopiu-pebbletext/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiupebbletext
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-port/package.json
+++ b/hellopiu-port/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu Port",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf94",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-port/setup.sh
+++ b/hellopiu-port/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiu-port
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-text/package.json
+++ b/hellopiu-text/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu Text",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf74",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-text/setup.sh
+++ b/hellopiu-text/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiutext
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopiu-timeline/package.json
+++ b/hellopiu-timeline/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Piu Timeline",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf95",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopiu-timeline/setup.sh
+++ b/hellopiu-timeline/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiu-timeline
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-gbitmap/package.json
+++ b/hellopoco-gbitmap/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - GBitmap",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf61",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-gbitmap/setup.sh
+++ b/hellopoco-gbitmap/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellobitmap
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-pdc-rotate/package.json
+++ b/hellopoco-pdc-rotate/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - PDC Rotate",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cfa5",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-pdc-rotate/setup.sh
+++ b/hellopoco-pdc-rotate/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopoco-pdc-rotate
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-pdc-scale/package.json
+++ b/hellopoco-pdc-scale/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - PDC Scale",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cfa6",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-pdc-scale/setup.sh
+++ b/hellopoco-pdc-scale/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopoco-pdc-scale
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-pdc-sequence/package.json
+++ b/hellopoco-pdc-sequence/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - PDC Sequence",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cfa4",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-pdc-sequence/setup.sh
+++ b/hellopoco-pdc-sequence/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopoco-pdc-sequence
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-pdc/package.json
+++ b/hellopoco-pdc/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - PDC",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cfa3",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-pdc/setup.sh
+++ b/hellopoco-pdc/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopoco-pdc
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-pebblegraphics/package.json
+++ b/hellopoco-pebblegraphics/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Poco Pebble Grahpics",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf72",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-pebblegraphics/setup.sh
+++ b/hellopoco-pebblegraphics/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopoco-pebblegraphics
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-pebbletext/package.json
+++ b/hellopoco-pebbletext/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Poco Pbl Text",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf7C",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-pebbletext/setup.sh
+++ b/hellopoco-pebbletext/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopocopebbletext
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellopoco-text/package.json
+++ b/hellopoco-text/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Poco Text",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf72",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellopoco-text/setup.sh
+++ b/hellopoco-text/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellopiutext
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellotimer/package.json
+++ b/hellotimer/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Timer",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf4e",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellotimer/setup.sh
+++ b/hellotimer/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellotimer
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellowatchface/package.json
+++ b/hellowatchface/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - Watchface",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf5f",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellowatchface/setup.sh
+++ b/hellowatchface/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.hellowatchface
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-rebble logs --qemu localhost:12344

--- a/hellowebsocket/package.json
+++ b/hellowebsocket/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - WebSocket",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cfB1",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellowebsocket/setup.sh
+++ b/hellowebsocket/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.websocket
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-pypkjs ./build/hellowebsocket.pbw  --debug

--- a/hellowebsocketclient/package.json
+++ b/hellowebsocketclient/package.json
@@ -8,6 +8,7 @@
   "pebble": {
     "displayName": "JS - WS client",
     "uuid": "12471cb1-caf2-4925-a63c-f27e9eb9cf99",
+    "projectType": "moddable",
     "sdkVersion": "3",
     "enableMultiJS": true,
     "targetPlatforms": [

--- a/hellowebsocketclient/setup.sh
+++ b/hellowebsocketclient/setup.sh
@@ -1,8 +1,0 @@
-set -e
-mkdir -p build
-mcrun -m ./src/embeddedjs/manifest.json -f x -t build -o ./build -s tech.moddable.websocketclient
-mkdir -p resources/mods
-cp build/bin/mac/mc/release/embeddedjs/mc.xsa ./resources/mods/mc.xsa
-rebble build
-rebble install --qemu localhost:12344
-pypkjs ./build/hellowebsocketclient.pbw  --debug


### PR DESCRIPTION
This adds "projectType": "moddable" to each package.json, which the Moddable-compatible pebble-tool uses to determine whether to run `mcrun` before building the project.

Since generating resources with `mcrun` is integrated into the new pebble-tool, the setup script is no longer necessary.

This also updates the README to remove mentions of `rebble` and instructions to set $MODDABLE, $PATH, and download QEMU, since those are now handled by pebble-tool.